### PR TITLE
Version 0.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,29 @@
 # DWork Web Framework
 
-## Current Version: 0.0.12
+## Current Version: 0.0.13
 
 ## Changelog
+
+### Version 0.0.13
+
+    - Routes::General
+        - Error and type structures have been moved to separate files.
+        - `Router.Dumper` has been modified to display the 'type' of the parameter.
+        - Added the option to enable Debug mode for the Router with Router.EnableDebug. Currently, this Debug mode provides verbose information about registered routes.
+    - Routes::Errors
+        - Improved error messages with a focus on providing more context to developers.
+    - Routes::Typing
+        - Route parameters are now "strongly" typed.
+        - When defining a parameter in a route, you must provide a type annotation in the format: <type:param>. Supported types include string, int, float, bool, and uuid.
+        - Parameters are checked at runtime, and if a user provides a value that is incompatible with the defined parameter type, a generic 404 error is returned.
+    - Routes::Tests
+        - Tests have been updated to align with the new type system.
+        - New tests have been created for type parsing.
+    - Examples::General
+        - Examples have been updated to match the new type system.
+    - TODOS:
+        - There is a need to manually cast parameters from the URL to their respective types, e.g., `id := dc.Params["id"].(int)`. The idea is to hide Params as a 'raw' variable and attach methods like parseInt(), parseFloat(), parseBool(), parseUUID(), maybe parseString() for safety and sanitization,  to the `context dc`.
+        - Implement descriptive errors for users in case of parameter type mismatches when a 'value' is provided.
 
 ### Version 0.0.12
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Note: The documentation for this project is currently under construction.**
 
-**Note: Project Version 0.0.12 is a work in progress.**
+**Note: Project Version 0.0.13 is a work in progress.**
 
 DWork Web is a lightweight web framework for Go, designed to simplify web application development. It is free from external dependencies and acts as an extension to Go's native net/http package.
 

--- a/example/rest-api/main.go
+++ b/example/rest-api/main.go
@@ -11,6 +11,8 @@ func main() {
 	router := routes.MakeRouter()
 	router.Enable()
 
+	router.EnableDebug()
+
 	RegisterUserRoutes(&router)
 
 	router.Dump()

--- a/example/rest-api/user.go
+++ b/example/rest-api/user.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 
 	"github.com/Diegiwg/dwork-web/lib/routes"
 )
@@ -45,13 +44,9 @@ func RegisterUserRoutes(router *routes.Routes) {
 	})
 
 	// Delete User
-	router.RegisterRoute(routes.DELETE, "/user/:id", func(dc routes.DWorkContext) {
+	router.RegisterRoute(routes.DELETE, "/user/<int:id>", func(dc routes.DWorkContext) {
 
-		id, err := strconv.Atoi(dc.Params["id"])
-		if err != nil {
-			http.Error(dc.Response, err.Error(), http.StatusInternalServerError)
-			return
-		}
+		id := dc.Params["id"].(int)
 
 		_, ok := users[id]
 		if !ok {
@@ -64,13 +59,9 @@ func RegisterUserRoutes(router *routes.Routes) {
 	})
 
 	// Get User
-	router.RegisterRoute(routes.GET, "/user/:id", func(dc routes.DWorkContext) {
+	router.RegisterRoute(routes.GET, "/user/<int:id>", func(dc routes.DWorkContext) {
 
-		id, err := strconv.Atoi(dc.Params["id"])
-		if err != nil {
-			http.Error(dc.Response, err.Error(), http.StatusInternalServerError)
-			return
-		}
+		id := dc.Params["id"].(int)
 
 		user, ok := users[id]
 		if !ok {

--- a/lib/routes/dump.go
+++ b/lib/routes/dump.go
@@ -12,12 +12,18 @@ func recursiveDump(node Routes, ident int) {
 	for key := range node {
 		color := "33"
 		name := key
-		if key == "@" {
-			color = "32"
-			name = "@:" + node[key].Param
+
+		if key == "" {
+			color = "36"
+			name = "index"
 		}
 
-		fmt.Println(strings.Repeat(" ", ident)+"\033["+color+"m["+name+"]:\033[0m", node[key])
+		if key == "@" {
+			color = "32"
+			name = fmt.Sprint("@:<", node[key].ParamType, ":", node[key].Param, ">")
+		}
+
+		fmt.Println(strings.Repeat(" ", ident)+"\033["+color+"m["+name+"]\033[0m", node[key])
 		recursiveDump(node[key].Routes, ident+2)
 	}
 

--- a/lib/routes/errors.go
+++ b/lib/routes/errors.go
@@ -1,35 +1,63 @@
 package routes
 
+import "fmt"
+
 type PathAlreadyExist struct {
 	path string
 }
 
 func (err PathAlreadyExist) Error() string {
-	return "Path already exist: '" + err.path + "'"
+	return fmt.Sprint("The '", err.path, "' path already exist.")
 }
 
-type ParamsConflictInDynamicRoute struct {
+type ParamsConflict struct {
 	path     string
 	param    string
 	conflict string
 }
 
-func (err ParamsConflictInDynamicRoute) Error() string {
-	return "Params conflict in dynamic route: '" + err.path + "'. The '" + err.param + "' parameter already exists, and an attempt was made to add the '" + err.conflict + "' parameter."
+func (err ParamsConflict) Error() string {
+	return fmt.Sprint("In the '", err.path, "' route there is already a parameter (", err.param, ") in the place where '", err.conflict, "' is being placed.")
 }
 
-type SameParamAlreadyExistsInDynamicRoute struct {
+type RepeatedParameter struct {
 	path  string
 	param string
 }
 
-func (err SameParamAlreadyExistsInDynamicRoute) Error() string {
-	return "Same param already exists in dynamic route: '" + err.path + "'. The '" + err.param + "' parameter already exists."
+func (err RepeatedParameter) Error() string {
+	return fmt.Sprint("The '", err.param, "' parameter already exists in the '", err.path, "' route.")
 }
 
-type InvalidHttpVerb struct {
-}
+type InvalidHttpVerb struct{}
 
 func (err InvalidHttpVerb) Error() string {
-	return "Invalid HTTP Verb"
+	return "Not valid HTTP verb in use."
+}
+
+type InvalidParamType struct {
+	Type  any
+	Param string
+	Path  string
+}
+
+func (err InvalidParamType) Error() string {
+	if err.Path == "" {
+		err.Path = "index"
+	}
+
+	return fmt.Sprint("The '", err.Type, "', in the '", err.Path, "' route is a invalid type for the param '", err.Param, "'.")
+}
+
+type InvalidParamStruct struct {
+	Param string
+	Path  string
+}
+
+func (err InvalidParamStruct) Error() string {
+	if err.Path == "" {
+		err.Path = "index"
+	}
+
+	return fmt.Sprint("The '", err.Param, "', in the '", err.Path, "' route is a invalid param struct.")
 }

--- a/lib/routes/parse_test.go
+++ b/lib/routes/parse_test.go
@@ -15,9 +15,11 @@ func TestParse(t *testing.T) {
 	r.RegisterRoute(GET, "/", nil)
 	r.RegisterRoute(GET, "/faq/project", nil)
 	r.RegisterRoute(GET, "/project/add", nil)
-	r.RegisterRoute(GET, "/project/:id", nil)
-	r.RegisterRoute(GET, "/user/:id/project/:name", nil)
-	r.RegisterRoute(GET, "/user/:id/posts/:name/show", nil)
+	r.RegisterRoute(GET, "/project/<int:id>", nil)
+	r.RegisterRoute(GET, "/user/<uuid:id>/project/<string:name>", nil)
+	r.RegisterRoute(GET, "/user/<uuid:id>/posts/<string:name>/show", nil)
+
+	r.Dump()
 
 	// End of Setup
 
@@ -36,11 +38,12 @@ func TestParse(t *testing.T) {
 			args: args{
 				path: "/",
 				wantRoute: &Route{
-					Kind:    "common",
-					Path:    "", // Index case
-					Param:   "",
-					Handler: nil,
-					Routes:  MakeRouter(),
+					Kind:      "common",
+					Path:      "", // Index case
+					Param:     "",
+					ParamType: NULL,
+					Handler:   nil,
+					Routes:    MakeRouter(),
 				},
 				wantParams: RouteParams{},
 			},
@@ -50,11 +53,12 @@ func TestParse(t *testing.T) {
 			args: args{
 				path: "/faq/project",
 				wantRoute: &Route{
-					Kind:    "common",
-					Path:    "project",
-					Param:   "",
-					Handler: nil,
-					Routes:  MakeRouter(),
+					Kind:      "common",
+					Path:      "project",
+					Param:     "",
+					ParamType: NULL,
+					Handler:   nil,
+					Routes:    MakeRouter(),
 				},
 				wantParams: RouteParams{},
 			},
@@ -64,11 +68,12 @@ func TestParse(t *testing.T) {
 			args: args{
 				path: "/project/add",
 				wantRoute: &Route{
-					Kind:    "common",
-					Path:    "add",
-					Param:   "",
-					Handler: nil,
-					Routes:  MakeRouter(),
+					Kind:      "common",
+					Path:      "add",
+					Param:     "",
+					ParamType: NULL,
+					Handler:   nil,
+					Routes:    MakeRouter(),
 				},
 				wantParams: RouteParams{},
 			},
@@ -78,41 +83,44 @@ func TestParse(t *testing.T) {
 			args: args{
 				path: "/project/1",
 				wantRoute: &Route{
-					Kind:    "special",
-					Path:    "@",
-					Param:   "id",
-					Handler: nil,
-					Routes:  MakeRouter(),
+					Kind:      "special",
+					Path:      "@",
+					Param:     "id",
+					ParamType: INT,
+					Handler:   nil,
+					Routes:    MakeRouter(),
 				},
-				wantParams: RouteParams{"id": "1"},
+				wantParams: RouteParams{"id": 1},
 			},
 		},
 		{
 			name: "Parse Dynamic Route With Two Params [OK]",
 			args: args{
-				path: "/user/1/project/cool project",
+				path: "/user/550e8400-e29b-41d4-a716-446655440000/project/cool project",
 				wantRoute: &Route{
-					Kind:    "special",
-					Path:    "@",
-					Param:   "name",
-					Handler: nil,
-					Routes:  MakeRouter(),
+					Kind:      "special",
+					Path:      "@",
+					Param:     "name",
+					ParamType: STRING,
+					Handler:   nil,
+					Routes:    MakeRouter(),
 				},
-				wantParams: RouteParams{"id": "1", "name": "cool project"},
+				wantParams: RouteParams{"id": "550e8400-e29b-41d4-a716-446655440000", "name": "cool project"},
 			},
 		},
 		{
 			name: "Parse Dynamic Route With Two Params and Static Part in Final [OK]",
 			args: args{
-				path: "/user/1/posts/cool post/show",
+				path: "/user/550e8400-e29b-41d4-a716-446655440000/posts/cool post/show",
 				wantRoute: &Route{
-					Kind:    "common",
-					Path:    "show",
-					Param:   "",
-					Handler: nil,
-					Routes:  MakeRouter(),
+					Kind:      "common",
+					Path:      "show",
+					Param:     "",
+					ParamType: NULL,
+					Handler:   nil,
+					Routes:    MakeRouter(),
 				},
-				wantParams: RouteParams{"id": "1", "name": "cool post"},
+				wantParams: RouteParams{"id": "550e8400-e29b-41d4-a716-446655440000", "name": "cool post"},
 			},
 		},
 	}

--- a/lib/routes/register_test.go
+++ b/lib/routes/register_test.go
@@ -41,7 +41,7 @@ func TestRegisterRoute(t *testing.T) {
 			name: "Register Dynamic Route [OK]",
 			args: args{
 				routes:   &r,
-				path:     "/project/:id",
+				path:     "/project/<int:id>",
 				expected: []string{"project", "@"},
 				handler:  nil,
 			},
@@ -50,7 +50,7 @@ func TestRegisterRoute(t *testing.T) {
 			name: "Register Dynamic Route With Two Params [OK]",
 			args: args{
 				routes:   &r,
-				path:     "/user/:id/project/:name",
+				path:     "/user/<int:id>/project/<string:name>",
 				expected: []string{"user", "@", "project", "@"},
 				handler:  nil,
 			},
@@ -59,7 +59,7 @@ func TestRegisterRoute(t *testing.T) {
 			name: "Register Dynamic Route With Two Params and Static Part in Final [OK]",
 			args: args{
 				routes:   &r,
-				path:     "/user/:id/project/:name/show",
+				path:     "/user/<int:id>/project/<string:name>/show",
 				expected: []string{"user", "@", "project", "@", "show"},
 				handler:  nil,
 			},
@@ -69,14 +69,14 @@ func TestRegisterRoute(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r.RegisterRoute(GET, tt.args.path, tt.args.handler) // TODO: Test others http verbs
 
-			node := tt.args.routes
+			node := r["GET"].Routes
 			for _, part := range tt.args.expected {
-				temp := (*node)[part]
+				temp := (node)[part]
 
 				if temp == nil {
 					t.Fail()
 				} else {
-					node = &temp.Routes
+					node = temp.Routes
 				}
 
 			}

--- a/lib/routes/router.go
+++ b/lib/routes/router.go
@@ -2,25 +2,7 @@ package routes
 
 import "net/http"
 
-type RouteParams map[string]string
-
-type DWorkContext struct {
-	Params   RouteParams
-	Response http.ResponseWriter
-	Request  *http.Request
-}
-
-type RouteHandler func(DWorkContext)
-
-type Route struct {
-	Kind    string
-	Path    string
-	Param   string
-	Handler RouteHandler
-	Routes  Routes
-}
-
-type Routes map[string]*Route
+var DEBUG_FLAG bool = false
 
 func MakeRouter() Routes {
 	return make(map[string]*Route)
@@ -46,3 +28,5 @@ func (routes *Routes) Enable() {
 		route.Handler(context)
 	})
 }
+
+func (routes *Routes) EnableDebug() { DEBUG_FLAG = true }

--- a/lib/routes/types.go
+++ b/lib/routes/types.go
@@ -1,0 +1,136 @@
+package routes
+
+import (
+	"net/http"
+	"regexp"
+	"strconv"
+
+	"github.com/Diegiwg/dwork-web/lib/logger"
+)
+
+type RouteParams map[string]any
+
+type DWorkContext struct {
+	Params   RouteParams
+	Response http.ResponseWriter
+	Request  *http.Request
+}
+
+type RouteHandler func(DWorkContext)
+
+type Route struct {
+	Kind      string
+	Path      string
+	Param     string
+	ParamType ParamTypes
+	Handler   RouteHandler
+	Routes    Routes
+}
+
+type Routes map[string]*Route
+
+type HTTPVerb int
+
+const (
+	GET HTTPVerb = iota
+	POST
+	PUT
+	PATCH
+	DELETE
+	HEAD
+	OPTIONS
+)
+
+func (verb HTTPVerb) Parse() (string, error) {
+	verbs := [...]string{"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"}
+	if verb < GET || verb > OPTIONS {
+		err := InvalidHttpVerb{}
+		logger.Error(err)
+		return "", err
+	}
+	return verbs[verb], nil
+}
+
+type ParamTypes string
+
+const (
+	EMPTY  ParamTypes = ""
+	NULL   ParamTypes = "NULL"
+	STRING ParamTypes = "string"
+	INT    ParamTypes = "int"
+	FLOAT  ParamTypes = "float"
+	BOOL   ParamTypes = "bool"
+	UUID   ParamTypes = "uuid"
+)
+
+func StringToParamType(value string) ParamTypes {
+	switch value {
+
+	case "string":
+		return STRING
+	case "int":
+		return INT
+	case "float":
+		return FLOAT
+	case "bool":
+		return BOOL
+	case "uuid":
+		return UUID
+	}
+
+	return NULL
+}
+
+func ParseParamType(value string, paramType ParamTypes, path string) (interface{}, error) {
+
+	if value == "" || paramType == NULL {
+		return nil, InvalidParamType{Type: paramType, Param: value, Path: path}
+	}
+
+	switch paramType {
+
+	case STRING:
+		return value, nil
+
+	case INT:
+		temp, err := strconv.Atoi(value)
+
+		if err != nil {
+			return nil, InvalidParamType{Type: paramType, Param: value, Path: path}
+		}
+
+		return temp, nil
+
+	case FLOAT:
+		temp, err := strconv.ParseFloat(value, 64)
+
+		if err != nil {
+			return nil, InvalidParamType{Type: paramType, Param: value, Path: path}
+		}
+
+		return temp, nil
+
+	case BOOL:
+		temp, err := strconv.ParseBool(value)
+
+		if err != nil {
+			return nil, InvalidParamType{Type: paramType, Param: value, Path: path}
+		}
+
+		return temp, nil
+
+	case UUID:
+		// * Regex from https://github.com/uuidjs/uuid/blob/bc46e198ab06311a9d82d3c9c6222062dd27f760/src/regex.js
+		test := regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000$`)
+
+		if !test.MatchString(value) {
+			return nil, InvalidParamType{Type: paramType, Param: value, Path: path}
+		}
+
+		return value, nil
+
+	}
+
+	return nil, InvalidParamType{Type: paramType, Param: value, Path: path}
+
+}

--- a/lib/routes/types_test.go
+++ b/lib/routes/types_test.go
@@ -1,0 +1,132 @@
+package routes
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseParamType(t *testing.T) {
+	type args struct {
+		value     string
+		paramType ParamTypes
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    interface{}
+		wantErr bool
+	}{
+		{
+			name: "Parse::String [OK]",
+			args: args{
+				value:     "test",
+				paramType: STRING,
+			},
+			want:    "test",
+			wantErr: false,
+		},
+		{
+			name: "Parse::Int [OK]",
+			args: args{
+				value:     "1",
+				paramType: INT,
+			},
+			want:    1,
+			wantErr: false,
+		},
+		{
+			name: "Parse::Float [OK]",
+			args: args{
+				value:     "1.1",
+				paramType: FLOAT,
+			},
+			want:    1.1,
+			wantErr: false,
+		},
+		{
+			name: "Parse::Bool [OK]",
+			args: args{
+				value:     "true",
+				paramType: BOOL,
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "Parse::UUID [OK]",
+			args: args{
+				value:     "00000000-0000-0000-0000-000000000000",
+				paramType: UUID,
+			},
+			want:    "00000000-0000-0000-0000-000000000000",
+			wantErr: false,
+		},
+		{
+			name: "Parse::Invalid [Error]",
+			args: args{
+				value:     "",
+				paramType: STRING,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Parse::String [Error]",
+			args: args{
+				value:     "",
+				paramType: STRING,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Parse::Int [Error]",
+			args: args{
+				value:     "a",
+				paramType: INT,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Parse::Float [Error]",
+			args: args{
+				value:     "b",
+				paramType: FLOAT,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Parse::Bool [Error]",
+			args: args{
+				value:     "c",
+				paramType: BOOL,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Parse::UUID [Error]",
+			args: args{
+				value:     "d",
+				paramType: UUID,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseParamType(tt.args.value, tt.args.paramType, "")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseParamType() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseParamType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Routes::General
    - Error and type structures have been moved to separate files.
    - `Router.Dumper` has been modified to display the 'type' of the parameter.
    - Added the option to enable Debug mode for the Router with Router.EnableDebug. Currently, this Debug mode provides verbose information about registered routes.
- Routes::Errors
    - Improved error messages with a focus on providing more context to developers.
- Routes::Typing
    - Route parameters are now "strongly" typed.
    - When defining a parameter in a route, you must provide a type annotation in the format: <type:param>. Supported types include string, int, float, bool, and uuid.
    - Parameters are checked at runtime, and if a user provides a value that is incompatible with the defined parameter type, a generic 404 error is returned.
- Routes::Tests
    - Tests have been updated to align with the new type system.
    - New tests have been created for type parsing.
- Examples::General
    - Examples have been updated to match the new type system.
- TODOS:
    - There is a need to manually cast parameters from the URL to their respective types, e.g., `id := dc.Params["id"].(int)`. The idea is to hide Params as a 'raw' variable and attach methods like parseInt(), parseFloat(), parseBool(), parseUUID(), maybe parseString() for safety and sanitization,  to the `context dc`.
    - Implement descriptive errors for users in case of parameter type mismatches when a 'value' is provided.